### PR TITLE
fix on griPcp()

### DIFF
--- a/R/learner_glm.R
+++ b/R/learner_glm.R
@@ -50,8 +50,6 @@ learner_glm <- function(ref, can, covars) {
   # probability of ocurrence prediction
   #####################################
 
-  covars <- strsplit(covars,'+',fixed=T)[[1]]
-  
   rr <- as.data.frame(ref)
   rr$val[rr$val > 0] <- 1
   

--- a/R/learner_nn.R
+++ b/R/learner_nn.R
@@ -51,8 +51,6 @@ learner_nn <- function(ref, can, covars) {
   # probability of ocurrence prediction
   #####################################
 
-  covars <- strsplit(covars,'+',fixed=T)[[1]]
-  
   rr <- as.data.frame(ref)
   rr$val[rr$val > 0] <- 1
   rr$val <- factor(rr$val, levels = c(0, 1))

--- a/R/learner_rf.R
+++ b/R/learner_rf.R
@@ -51,8 +51,6 @@ learner_rf <- function(ref, can, covars) {
   # probability of ocurrence prediction
   #####################################
 
-  covars <- strsplit(covars,'+',fixed=T)[[1]]
-  
   rr <- as.data.frame(ref)
   rr$val[rr$val > 0] <- 1
   rr$val <- factor(rr$val, levels = c(0, 1))

--- a/R/learner_svm.R
+++ b/R/learner_svm.R
@@ -50,8 +50,6 @@ learner_svm <- function(ref, can, covars) {
   #####################################  
   # probability of ocurrence prediction
   #####################################
-
-  covars <- strsplit(covars,'+',fixed=T)[[1]]
   
   rr <- as.data.frame(ref)
   rr$val[rr$val > 0] <- 1

--- a/R/learner_xgboost.R
+++ b/R/learner_xgboost.R
@@ -51,8 +51,6 @@ learner_xgboost <- function(ref, can, covars) {
   # probability of ocurrence prediction
   #####################################
 
-  covars <- strsplit(covars,'+',fixed=T)[[1]]
-  
   rr <- as.data.frame(ref)
   rr$val[rr$val > 0] <- 1
   # rr$val <- factor(rr$val, levels = c(0, 1))

--- a/R/predday.R
+++ b/R/predday.R
@@ -11,14 +11,15 @@
 #' @param coords_as_preds logical. If TRUE (default), "coords" are also taken as predictors.
 #' @param date value of class "Date"
 #' @param thres numeric. Maximum radius (in km) where neighboring stations will be searched. NA value uses the whole spatial domain.
+#' @param dir_name character. Name of the of the folder in which the data will be saved. Default NA uses the original names.
 #' @importFrom foreach foreach %dopar%
 #' @importFrom terra vect rast crds writeRaster as.points
 #' @noRd
 #' 
-predday <- function(x, grid, sts, model_fun, neibs, coords, crs, coords_as_preds, date, thres) {
+predday <- function(x, grid, sts, model_fun, neibs, coords, crs, coords_as_preds, date, thres, dir_name) {
   
-  dir.create('pred', showWarnings = FALSE)
-  dir.create('err', showWarnings = FALSE)
+  dir.create(paste0("pred", ifelse(is.na(dir_name), "", paste0("_", dir_name))), showWarnings = FALSE)
+  dir.create(paste0("err", ifelse(is.na(dir_name), "", paste0("_", dir_name))), showWarnings = FALSE)
   
   n <- names(sts)
   if(!coords_as_preds) n <- n[-match(coords,names(sts))]
@@ -74,8 +75,8 @@ predday <- function(x, grid, sts, model_fun, neibs, coords, crs, coords_as_preds
     rp <- terra::rast(cbind(terra::crds(grid),rr[,1]), type="xyz", crs=crs)
     re <- terra::rast(cbind(terra::crds(grid),rr[,2]), type="xyz", crs=crs)
     names(rp) <- names(re) <- date
-    terra::writeRaster(rp, paste0('./pred/',gsub('-','',date),'.tif'),overwrite=TRUE)
-    terra::writeRaster(re, paste0('./err/',gsub('-','',date),'.tif'),overwrite=TRUE)
+    terra::writeRaster(rp, paste0(paste0("./pred", ifelse(is.na(dir_name), "", paste0("_", dir_name)), "/"), gsub('-','',date),'.tif'), overwrite = TRUE)
+    terra::writeRaster(re, paste0(paste0("./err", ifelse(is.na(dir_name), "", paste0("_", dir_name)), "/"), gsub('-','',date),'.tif'), overwrite = TRUE)
     
   }
   


### PR DESCRIPTION
Hi @rsnotivoli 

The PR #5 was working great before the changes that you made (adding dyncovars argument). The following issue was found:
- "names(dyncovars1) <- paste('dynvar1.day',1:terra::nlyr(dyncovars1))" is not correct because there was an issue when dealing with blank space on "covars <- strsplit(covars,'+',fixed=T)[[1]]". In this case "worked well" because only one predictor was used
- "names(dyncovars1) <- paste('dynvar1.day',1:terra::nlyr(dyncovars1), sep = "_")" worked well with the original learning function models. That was corrected in this PR (just in the example)

However, by testing the examples in Switzerland and Valencia. There was another issues in gridPcp() for "multiple days":
- "dgrid" was not saving the time step indicated because the "for" uses the index "i", which is the same for higher-level "for". I corrected this by changing the index
-  A similar issue was found with "grid". I created a new object "dgrid" where the new layers will be saved and used later

Besides this, I also added a new argument in gridPcp() called "dir_name" that names the folder in which the grids would be saved. The default option is NA; original names are used.

With these changes, the examples worked well and are equivalent to the first time

Best,
Adrian