### PR TITLE
condition for zero in stand_qq.R

### DIFF
--- a/R/stand_qq.R
+++ b/R/stand_qq.R
@@ -8,9 +8,12 @@
 #' @noRd
 
 stand_qq <- function(o, s){
+  
+  suppressMessages(require(qmap))
+  
   w0 <- which(s == 0)
   ww <- which((o + s) != 0)
-  if(length(ww) < 5) return(s) else{
+  if (length(ww) < 5 | sww == 0 | oww == 0) return(s) else {
     qm.fit <- fitQmap(o[ww],
                       s[ww],
                       method = "QUANT",


### PR DESCRIPTION
Hi @rsnotivoli 

I just noticed a bug in stand_qq.R that happens with the zero correction issue. I added a condition to avoid this issue. It now follows the code of SC-[PREC4SA](https://github.com/adrHuerta/sc-prec4sa/blob/main/R/03_gap-filling/gf-helpers.R)
Also, I have added "require(qmap)" to use the package inside the functions, as it seems that the functions are not exported

Best,
Adrian