### PR TITLE
Stand qq fix2

### DIFF
--- a/R/stand_qq.R
+++ b/R/stand_qq.R
@@ -8,9 +8,12 @@
 #' @noRd
 
 stand_qq <- function(o, s){
+  
+  suppressMessages(require(qmap))
+  
   w0 <- which(s == 0)
   ww <- which((o + s) != 0)
-  if(length(ww) < 5) return(s) else{
+  if (length(ww) < 5 | sww == 0 | oww == 0) return(s) else {
     qm.fit <- fitQmap(o[ww],
                       s[ww],
                       method = "QUANT",

--- a/R/stand_qq.R
+++ b/R/stand_qq.R
@@ -12,7 +12,7 @@ stand_qq <- function(o, s){
   w0 <- which(s == 0)
   ww <- which((o + s) != 0)
   sww <- var(s[ww])
-  oww <- var(s[ww])
+  oww <- var(o[ww])
   
   if (length(ww) < 5 | sww == 0 | oww == 0) return(s) else {
     qm.fit <- fitQmap(o[ww],

--- a/R/stand_qq.R
+++ b/R/stand_qq.R
@@ -9,10 +9,11 @@
 
 stand_qq <- function(o, s){
   
-  suppressMessages(require(qmap))
-  
   w0 <- which(s == 0)
   ww <- which((o + s) != 0)
+  sww <- var(s[ww])
+  oww <- var(s[ww])
+  
   if (length(ww) < 5 | sww == 0 | oww == 0) return(s) else {
     qm.fit <- fitQmap(o[ww],
                       s[ww],
@@ -22,13 +23,20 @@ stand_qq <- function(o, s){
     # wet.day was not set before (creating fake automatic wet.day)
     # wet.day = 0 = FALSE same    
     w <- which(!is.na(s))
-    if(length(w) < length(s)){
+    
+    if (length(w) < length(s)) {
+      
       xx <- doQmap(s[w], qm.fit)
       s[w] <- xx
-    } else{
+      
+    } else {
+      
       s <- doQmap(s, qm.fit)
+      
     }
+    
     s[w0] <- 0
-    return(round(s,2))
+    
+    return(round(s, 2))
     }
 }


### PR DESCRIPTION
Hi @rsnotivoli

I just noticed a bug in stand_qq.R that happens with the zero correction issue. I added a condition to avoid this issue, which checks if the variance equals 0 (all values are the same) in the data to apply the bias correction. If the variance = 0 (in model or observed), it would not do the bias correction. 

Best,
Adrian