### PR TITLE
Kendall::MannKendall to trend::mk.test

### DIFF
--- a/R/hmg_Ts.R
+++ b/R/hmg_Ts.R
@@ -18,7 +18,7 @@
 #' @importFrom xts xts apply.yearly
 #' @importFrom zoo coredata rollapply
 #' @importFrom geosphere distHaversine
-#' @importFrom Kendall MannKendall
+#' @importFrom trend mk.test
 #' @importFrom pracma detrend
 #' @importFrom car durbinWatsonTest
 #' @importFrom BreakPoints pettit man.whi stu SNHT Buishand_R

--- a/R/hmg_cleaning_trend_ar1.R
+++ b/R/hmg_cleaning_trend_ar1.R
@@ -2,11 +2,12 @@ hmg_cleaning_trend_ar1 <- function(time_serie, p_value = 0.05){
   
   
   # Apply detrending
-  sample_value <- as.numeric(time_serie)
-  mk_res <- Kendall::MannKendall(time_serie)
+  sample_value <- as.numeric(sample_value)
+  mk_res <- trend::mk.test(sample_value)
+  # mk_res <- Kendall::MannKendall(sample_value)
   
   # removing trend if mk_res$sl < p_value
-  if (as.numeric(mk_res$sl) < p_value) {
+  if (as.numeric(mk_res$p.value) < p_value) {
     
     res <- pracma::detrend(sample_value, tt = "linear")
     zoo::coredata(time_serie) <- res


### PR DESCRIPTION
Hi @rsnotivoli,

I replaced Kendall::MannKendall with trend::mk.test in R/hmg_Ts.R and R/hmg_cleaning_trend_ar1.R to address the archiving of the Kendall package.

Best,
Adrian